### PR TITLE
Clean up Events for Metrics and Worker Update Threads

### DIFF
--- a/bq/app.py
+++ b/bq/app.py
@@ -63,6 +63,10 @@ class BeanQueue:
         self.worker_service_cls = worker_service_cls
         self.dispatch_service_cls = dispatch_service_cls
         self._engine = engine
+        self._worker_update_shutdown_event: threading.Event = threading.Event()
+        # noop if metrics thread is not started yet, shutdown if it is started
+        self._metrics_server_shutdown: typing.Callable[[], None] = lambda : None
+
 
     def create_default_engine(self):
         return create_engine(
@@ -184,7 +188,10 @@ class BeanQueue:
                 )
                 sys.exit(0)
 
-            time.sleep(self.config.WORKER_HEARTBEAT_PERIOD)
+            do_shutdown = self._worker_update_shutdown_event.wait(self.config.WORKER_HEARTBEAT_PERIOD)
+            if do_shutdown:
+                return
+
             current_worker.last_heartbeat = func.now()
             db.add(current_worker)
             db.commit()
@@ -244,6 +251,8 @@ class BeanQueue:
             functools.partial(self._serve_http_request, worker_id),
             handler_class=WSGIRequestHandlerWithLogger,
         ) as httpd:
+            # expose graceful shutdown to the main thread
+            self._metrics_server_shutdown= httpd.shutdown
             logger.info("Run metrics HTTP server on %s:%s", host, port)
             httpd.serve_forever()
 
@@ -307,7 +316,7 @@ class BeanQueue:
         events.worker_init.send(self, worker=worker)
 
         logger.info("Processing tasks in channels = %s ...", channels)
-
+        # Graceful shutdown of worker update event on exit of the worker
         worker_update_thread = threading.Thread(
             target=functools.partial(
                 self.update_workers,
@@ -357,9 +366,14 @@ class BeanQueue:
         except (SystemExit, KeyboardInterrupt):
             db.rollback()
             logger.info("Shutting down ...")
+            self._worker_update_shutdown_event.set()
             worker_update_thread.join(5)
             if metrics_server_thread is not None:
-                metrics_server_thread.join(5)
+                # set a threading event, waits until server is shutdown
+                # serve the ongoing requests
+                self._metrics_server_shutdown()
+                metrics_server_thread.join(1)
+
 
         worker.state = models.WorkerState.SHUTDOWN
         db.add(worker)

--- a/bq/config.py
+++ b/bq/config.py
@@ -57,8 +57,18 @@ class Config(BaseSettings):
     def assemble_db_connection(
         cls, v: typing.Optional[str], info: ValidationInfo
     ) -> typing.Any:
-        if isinstance(v, (str, MultiHostUrl)):
+        if isinstance(v, str):
             return v
+        # Notice: Older Pydantic version (2.7), PostgresDsn is an annotated MultiHostUrl object,
+        #         we cannot use isinstance with PostgresDsn directly. We need to check and see if PostgresDsn
+        #         is an annotated type or not before we decide how to check if the passed in object is an
+        #         PostgresDsn or not.
+        if typing.get_origin(PostgresDsn) is typing.Annotated:
+            if isinstance(v, MultiHostUrl):
+                return v
+        else:
+            if isinstance(v, PostgresDsn):
+                return v
         if v is not None:
             raise ValueError("Unexpected DATABASE_URL type")
         return PostgresDsn.build(


### PR DESCRIPTION
Hi there,
On exit, the worker process joins for 5s on worker update and metrics thread and then kills them.
I have added thread safe ways to signal both threads to not process the next rounds their tasks but carry on their current ones.
This would lead to a Ctrl-c or other kill signals to exit very fast and only to wait in the case the thread have ongoing code and exit when the ongoing one is finished.


For metrics thread, there is a shutdown method for the http server implemented which sets a threading.Event and the http server in its loop would check the event before processing the next request, thus would continue serving the ongoing request and would stop any other requests after the shutdown is requested.
[Here](https://github.com/python/cpython/blob/82f74eb2344cdb3197c726d1216e413ee61a30b3/Lib/socketserver.py#L247) is the code for the shutdown method of `WSGIServer`. I just expose the method to the main thread and call it, then I would just wait for 1s to process its open requests.
In the case of  a user not opting in to have metrics thread, I initialized  a noop function instead of shutdown, it wouldn't be called anyway. 

For worker update thread, I have added a  `threading.Event` instead of `time.sleep` in the worker update thread, instead of sleeping the thread would wait with a timeout of 30s on the shutdown event, if it is set, the thread would wake up and exit.
If the event is set during an active working time of the thread, it would process until the end of the code and then checks it and exits.
 